### PR TITLE
Add custom qsub option parsing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Arguments are overridden in the following order, aliases are also defined and ca
 4) Profile `cluster_config` file <rulename> entries
 5) `--cluster-config` parsed to Snakemake (deprecated since Snakemake 5.10)
 
-## Resource mapping
+## Resource and option mapping
 
 To allow more expressive resource requests we map some simple names to the SGE options and resources. These can be used for example in `cluster.yaml` to make the configuration simpler to read.
 
@@ -56,6 +56,19 @@ __resources__:
 Allows you to request with `coproc_v100=1`, `gpu=1` or `nvidia_gpu=1` in the cluster config files or snakemake rule resources all of which will actually set `-j coproc_v100=1` for qsub.
 
 Memory (`s_vmem`, `h_vmem` and aliases) must be given in gigabytes.
+
+
+Custom SGE options can be specified in `__options__` in the profile folder in the same way as resources.  
+
+For example:
+
+```
+__options__:
+  jc: 
+    - "jc"
+    - "job_class"
+```
+
 
 A full list of the default supported SGE options and resource requests with their aliases is:
 

--- a/{{cookiecutter.profile_name}}/sge-submit.py
+++ b/{{cookiecutter.profile_name}}/sge-submit.py
@@ -98,6 +98,26 @@ def add_custom_resources(resources, resource_mapping=RESOURCE_MAPPING):
             if val != key:
                 resource_mapping[key] += (val,)
 
+def add_custom_options(options, option_mapping=OPTION_MAPPING):
+    """Adds new options to option_mapping.
+
+       options -> dict where key is sge option name and value is a single name
+                  or a list of names to be used as aliased
+    """
+    for key, val in options.items():
+        if key not in option_mapping:
+            option_mapping[key] = tuple()
+
+        # make sure the option name itself is an alias
+        option_mapping[key] += (key,)
+        if isinstance(val, list):
+            for alias in val:
+                if val != key:
+                    option_mapping[key] += (alias,)
+        else:
+            if val != key:
+                option_mapping[key] += (val,)
+
 def parse_jobscript():
     """Minimal CLI to require/only accept single positional argument."""
     p = argparse.ArgumentParser(description="SGE snakemake submit script")
@@ -213,6 +233,8 @@ job_properties = read_job_properties(jobscript)
 cluster_config = load_cluster_config(CLUSTER_CONFIG)
 
 add_custom_resources(cluster_config["__resources__"])
+
+add_custom_options(cluster_config["__options__"])
 
 # qsub default arguments
 update_double_dict(qsub_settings, parse_qsub_settings(parse_qsub_defaults(QSUB_DEFAULTS)))

--- a/{{cookiecutter.profile_name}}/{{cookiecutter.cluster_config}}.yaml
+++ b/{{cookiecutter.profile_name}}/{{cookiecutter.cluster_config}}.yaml
@@ -3,6 +3,12 @@ __resources__:
     - "gpu"
     - "nvidia_gpu"
 
+__options__:
+  jc:
+    - "jc"
+    - "jclass"
+    - "job_class"
+
 __default__:
   join: yes
   output: logs/sge/snakejob.{rulename}.{jobid}.log


### PR DESCRIPTION
This profile currently allows custom resources to be named via the cluster_config.yaml file (which are translated to the form: `-l name=value`), but does not allow custom options to be similarly defined (which have to be translated to the form: `-option [value]`).

This is a major limitation for use of this snakemake profile for workflows with rules that require qsub options which are not currently specified in the sge-submit.py script (https://github.com/Snakemake-Profiles/sge/blob/b70ce10332ae67fa8c77459e11330b2acf46bc1c/%7B%7Bcookiecutter.profile_name%7D%7D/sge-submit.py#L28).

So, I have added functionality to allow custom qsub options to be specified in the cluster_config.yaml file in the same way as custom resources.